### PR TITLE
Crea custom hook para fetchear la API de econDB

### DIFF
--- a/src/hooks/useFetchTicker.js
+++ b/src/hooks/useFetchTicker.js
@@ -1,13 +1,13 @@
 import { useState, useEffect } from "react";
 
-export const useFetchIndex = (index) => {
+export const useFetchTicker = (ticker) => {
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [controller, setController] = useState(null)
 
   useEffect(() => {
-    const URL = `https://www.econdb.com/api/series/${index}/?API_TOKEN=ed4c18f504bdb799ab4e0d431658ad73fe1a37f5&format=json`
+    const URL = `https://www.econdb.com/api/series/${ticker}/?API_TOKEN=ed4c18f504bdb799ab4e0d431658ad73fe1a37f5&format=json`
 
     const abortController = new AbortController();
     setController(abortController);
@@ -24,7 +24,7 @@ export const useFetchIndex = (index) => {
       })
       .finally(() => setLoading(false));
 
-  }, [index]);
+  }, [ticker]);
 
   const handleCancelRequest = () => {
     if (controller) {


### PR DESCRIPTION
El custom hook retorna 4 valores, la data, el loading (boolean, funciona como un isLoading), error (default null) y handleCancelRequest para cancelar la request. La API es llamada cada vez que el parámetro ticker cambia, el estado del ticker tiene que ser manejado en el lado del componente en el que está siendo utilizado. 